### PR TITLE
Fix a silent blank page on critial errors

### DIFF
--- a/core/class/uploader.php
+++ b/core/class/uploader.php
@@ -696,7 +696,8 @@ class uploader {
     protected function callBack($url, $message="") {
         $message = text::jsValue($message);
 
-        if ((get_class($this) == "kcfinder\\browser") && ($this->action != "browser"))
+        if ((get_class($this) == "kcfinder\\browser") 
+	    && ($this->action !== null) && ($this->action != "browser"))
             return;
 
         if (isset($this->opener['name'])) {


### PR DESCRIPTION
Currently if there is a critical error during early object construction
the script just dies silently. This patch fixes it making sure that the error
message would be passed down and e.g. displayed in a message box.
One example of such error is:

> Cannot find any of the supported PHP image extensions!