### PR TITLE
Add integration/authentication for Yii1 framework running on php8 server.

### DIFF
--- a/core/class/session.php
+++ b/core/class/session.php
@@ -43,7 +43,7 @@ class session
             $session = & $this->config[self::SESSION_VAR];
 
             if (!is_array($session) && !$session instanceof \Traversable) {
-                $session = $this->getDefaultSession()[$session];
+                $session = $this->getDefaultSession()[$session] ?? [];
 
                 if (!is_array($session)) {
                     $session = array();

--- a/core/types/type_mime.php
+++ b/core/types/type_mime.php
@@ -17,7 +17,7 @@ namespace kcfinder;
 class type_mime {
 
     public function checkFile($file, array $config) {
-        if (!class_exists("finfo"))
+        if (!extension_loaded("fileinfo"))
             return "Fileinfo PECL extension is missing.";
 
         if (!isset($config['params']))

--- a/integration/Yii.php
+++ b/integration/Yii.php
@@ -1,0 +1,40 @@
+<?php namespace kcfinder\integration;
+
+class Yii {
+    protected static $authenticated = null;
+    static function checkAuthentication() {
+        if (self::$authenticated !== null) {
+            return self::authenticated;
+        }
+        $current_cwd = getcwd();
+        chdir('..');
+        require './vendor/autoload.php';
+        $dir = dirname(__DIR__, 2);
+        \Yii::createWebApplication($dir . '/protected/config/main.php');
+        $state = \Yii::app()->user->getState('id');
+
+        if ($state === null) {
+            // not authenticated
+            self::$authenticated = false;
+            return false;
+        }
+        /*
+         * Intentionally don't restore pwd if not authenticated, so that file
+         * system related functionality is only for authenticated users.
+         */
+        chdir($current_cwd);
+        if (!isset($_SESSION['KCFINDER'])) {
+            $_SESSION['KCFINDER'] = array();
+        }
+        if(!isset($_SESSION['KCFINDER']['disabled'])) {
+            $_SESSION['KCFINDER']['disabled'] = false;
+        }
+        $_SESSION['KCFINDER']['_check4htaccess'] = false;
+        $_SESSION['KCFINDER']['uploadURL'] = $_SERVER['KCFINDER_UPLOAD_URL'];
+        $_SESSION['KCFINDER']['uploadDir'] = $_SERVER['KCFINDER_UPLOAD_DIR'];
+        $_SESSION['KCFINDER']['theme'] = 'default';
+        self::$authenticated = true;
+        return true;
+    }
+}
+\kcfinder\integration\Yii::checkAuthentication();

--- a/integration/Yii.php
+++ b/integration/Yii.php
@@ -8,7 +8,7 @@ class Yii {
         }
         $current_cwd = getcwd();
         chdir('..');
-        require './vendor/autoload.php';
+        include './vendor/autoload.php';
         $dir = dirname(__DIR__, 2);
         \Yii::createWebApplication($dir . '/protected/config/main.php');
         $state = \Yii::app()->user->getState('id');
@@ -26,7 +26,7 @@ class Yii {
         if (!isset($_SESSION['KCFINDER'])) {
             $_SESSION['KCFINDER'] = array();
         }
-        if(!isset($_SESSION['KCFINDER']['disabled'])) {
+        if (!isset($_SESSION['KCFINDER']['disabled'])) {
             $_SESSION['KCFINDER']['disabled'] = false;
         }
         $_SESSION['KCFINDER']['_check4htaccess'] = false;
@@ -37,4 +37,6 @@ class Yii {
         return true;
     }
 }
-\kcfinder\integration\Yii::checkAuthentication();
+if (!\kcfinder\integration\Yii::checkAuthentication()) {
+    die("NOT AUTHORISED. SESSION TIMED OUT.");
+}

--- a/lib/class_image.php
+++ b/lib/class_image.php
@@ -116,8 +116,8 @@ abstract class image {
             $img = $image->image;
 
         } elseif (is_array($image)) {
-            list($key, $width) = each($image);
-            list($key, $height) = each($image);
+            $width = $image[0];
+            $height = $image[1];
             $img = $this->getBlankImage($width, $height);
 
         } else

--- a/lib/class_image_gd.php
+++ b/lib/class_image_gd.php
@@ -238,7 +238,7 @@ class image_gd extends image {
     // PSEUDO-ABSTRACT STATIC METHODS
 
     static function available() {
-        return function_exists("imagecreatefromjpeg");
+        return extension_loaded('gd');
     }
 
     static function checkImage($file) {

--- a/lib/class_image_gmagick.php
+++ b/lib/class_image_gmagick.php
@@ -235,7 +235,7 @@ class image_gmagick extends image {
     // PSEUDO-ABSTRACT STATIC METHODS
 
     static function available() {
-        return class_exists("Gmagick");
+        return extension_loaded("gmagick");
     }
 
     static function checkImage($file) {

--- a/lib/class_image_imagick.php
+++ b/lib/class_image_imagick.php
@@ -237,7 +237,7 @@ class image_imagick extends image {
     // PSEUDO-ABSTRACT STATIC METHODS
 
     static function available() {
-        return class_exists("\\Imagick");
+        return extension_loaded("imagick");
     }
 
     static function checkImage($file) {

--- a/lib/helper_file.php
+++ b/lib/helper_file.php
@@ -138,7 +138,7 @@ class file {
   * @return string */
 
     static function getMimeType($filename, $magic=null) {
-        if (class_exists("finfo")) {
+        if (extension_loaded("fileinfo")) {
             $finfo = new \finfo(FILEINFO_MIME, $magic);
             if ($finfo) {
                 $mime = $finfo->file($filename);

--- a/tpl/tpl_javascript.php
+++ b/tpl/tpl_javascript.php
@@ -18,7 +18,7 @@
 ?>
 <script type="text/javascript">
 _.version = "<?php echo self::VERSION ?>";
-_.support.zip = <?php echo (class_exists('ZipArchive') && !$this->config['denyZipDownload']) ? "true" : "false" ?>;
+_.support.zip = <?php echo (extension_loaded('zip') && !$this->config['denyZipDownload']) ? "true" : "false" ?>;
 _.support.check4Update = <?php echo ((!isset($this->config['denyUpdateCheck']) || !$this->config['denyUpdateCheck']) && (ini_get("allow_url_fopen") || function_exists("http_get") || function_exists("curl_init") || function_exists('socket_create'))) ? "true" : "false" ?>;
 _.lang = "<?php echo text::jsValue($this->lang) ?>";
 _.type = "<?php echo text::jsValue($this->type) ?>";


### PR DESCRIPTION
Some changes required to get kcfinder working with an integration for testing against Yii for authentication:

* Use extension_loaded instead of class_exists so Yii's autoloader isn't triggered.
* Similarly use extension_loaded instead of function_exists
* The 'each' keyword was removed in PHP 8.0 - alternative/fix added.